### PR TITLE
Add sticky footer to all pages

### DIFF
--- a/bet-on-anything/src/app/format-test/page.tsx
+++ b/bet-on-anything/src/app/format-test/page.tsx
@@ -1,0 +1,28 @@
+export default function FormatTest() {
+  const generateFillerContent = () => {
+    const fillerContent = [];
+    for (let i = 0; i < 100; i++) {
+      fillerContent.push(<p key={i}>More filler content to ensure vertical scrolling.</p>);
+    }
+    fillerContent.push(<p key={100}>This is the last filler content.</p>);
+    return fillerContent;
+  };
+
+  return (
+    <div>
+      <h1>Format Test</h1>
+      <p>This is a format test page with filler content for vertical scrolling.</p>
+      <h2>Heading 2</h2>
+      <p>Some filler content under heading 2.</p>
+      <h3>Heading 3</h3>
+      <p>Some filler content under heading 3.</p>
+      <h4>Heading 4</h4>
+      <p>Some filler content under heading 4.</p>
+      <h5>Heading 5</h5>
+      <p>Some filler content under heading 5.</p>
+      <h6>Heading 6</h6>
+      <p>Some filler content under heading 6.</p>
+      {generateFillerContent()}
+    </div>
+  );
+}

--- a/bet-on-anything/src/app/layout.tsx
+++ b/bet-on-anything/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
+import Link from "next/link";
 import "./globals.css";
 
 const geistSans = localFont({
@@ -29,6 +30,17 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        <footer className="sticky bottom-0 w-full bg-gray-800 text-white py-4">
+          <div className="container mx-auto text-center">
+            <Link href="/" className="mx-2 hover:underline">
+              Home
+            </Link>
+            <span className="mx-2">|</span>
+            <Link href="/about" className="mx-2 hover:underline">
+              About
+            </Link>
+          </div>
+        </footer>
       </body>
     </html>
   );

--- a/bet-on-anything/src/app/page.tsx
+++ b/bet-on-anything/src/app/page.tsx
@@ -48,53 +48,6 @@ export default function Home() {
           Create table
         </button>
       </main>
-      <footer className="row-start-3 flex gap-6 flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="https://nextjs.org/icons/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="https://nextjs.org/icons/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="https://nextjs.org/icons/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
     </div>
   );
 }


### PR DESCRIPTION
Fixes #10

Add a sticky footer to the site layout and create a format test page.

* **Add sticky footer**: Add a sticky footer component to `bet-on-anything/src/app/layout.tsx` with links to the home and about pages, centered and separated by a pipe.
* **Remove existing footer**: Remove the existing footer from `bet-on-anything/src/app/page.tsx`.
* **Create format test page**: Add a new format test page in `bet-on-anything/src/app/format-test/page.tsx` with filler content for vertical scrolling, including various heading sizes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/NoahWright87/bet-on-anything/issues/10?shareId=ae694f31-3ae4-47bf-ae5c-22b4119456b8).